### PR TITLE
pass vagrant ssh-config options to ssh during rsync

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,8 +3,9 @@
 echo "Building Nginx for RHEL/CentOS/SL 7...."
 
 vagrant up --no-provision
+SSHARGS=`vagrant ssh-config | awk 'NF && !/^Host / {print " -o "$1"="$2}'`
 vagrant provision --provision-with build
-rsync -e "ssh -p2222 -i $HOME/.vagrant.d/insecure_private_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" vagrant@127.0.0.1:rpmbuild/RPMS/x86_64/* packages/
-rsync -e "ssh -p2222 -i $HOME/.vagrant.d/insecure_private_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" vagrant@127.0.0.1:rpmbuild/SRPMS/* packages/
+rsync -e "ssh $SSHARGS" vagrant@127.0.0.1:rpmbuild/RPMS/x86_64/* packages/
+rsync -e "ssh $SSHARGS" vagrant@127.0.0.1:rpmbuild/SRPMS/* packages/
 vagrant destroy
 

--- a/generate-spec.sh
+++ b/generate-spec.sh
@@ -3,7 +3,8 @@
 echo "Generating Nginx RPM spec for RHEL/CentOS/SL 7...."
 
 vagrant up --no-provision
+SSHARGS=`vagrant ssh-config | awk 'NF && !/^Host / {print " -o "$1"="$2}'`
 vagrant provision --provision-with spec
-rsync -e "ssh -p2222 -i $HOME/.vagrant.d/insecure_private_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" vagrant@127.0.0.1:rpmbuild/SPECS/* specs/
+rsync -e "ssh $SSHARGS" vagrant@127.0.0.1:rpmbuild/SPECS/* specs/
 vagrant destroy
 


### PR DESCRIPTION
Vagrant assigns SSH ports dynamically and the hardcoded -p2222 made rsync connect to a different VM. This pull request uses the output of vagrant ssh-config to pass the correct options to ssh. It's still a bit of a hack, though. The alternative would be to write the output of vagrant ssh-config to a temp file and pass that to ssh -F. 
